### PR TITLE
Fix dollar escapes at beginning of line

### DIFF
--- a/scripts/generate_textbook.py
+++ b/scripts/generate_textbook.py
@@ -84,6 +84,9 @@ def _clean_lines(lines, filepath):
             for char in inline_replace_chars:
                 line = line.replace('\\{}'.format(char), '\\\\{}'.format(char))
         line = line.replace(' \\$', ' \\\\$')
+        # Escaped dollar could be at beginning of line
+        if line.startswith('\\$'):
+            line = '\\' + line
         lines[ii] = line
     return lines
 


### PR DESCRIPTION
If the escaped dollar is at the beginning of the line, it does not get
replaced with the previous code, because it requires a preceding space.

This could also be done with a fancy regexp, but hey.